### PR TITLE
fix to getWeekDay()

### DIFF
--- a/protege.js
+++ b/protege.js
@@ -1063,7 +1063,7 @@ Object.extend(Date.prototype, (function() {
 	}
 
 	function getWeekDay(){
-		var days = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+		var days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
 		return days[this.getDay()];
 	}
 


### PR DESCRIPTION
The array of days was not indexed according to Date.prototype.getDay() https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay
